### PR TITLE
Fixes for whatsapp

### DIFF
--- a/healthcheck/requirements.txt
+++ b/healthcheck/requirements.txt
@@ -1,1 +1,2 @@
+urllib3<2
 twilio

--- a/processConnectMessage/lambda_function.py
+++ b/processConnectMessage/lambda_function.py
@@ -154,8 +154,8 @@ def send_attachment(userContact,channel,url,fileName,mimeType,systemNumber):
         print(message.sid)
     elif(channel=='whatsapp'):
         WHATS_PHONE_ID = connect_config['WHATS_PHONE_ID']
-        WHATS_TOKEN = connect_config['WHATS_TOKEN']
-        URL = 'https://graph.facebook.com/v13.0/'+WHATS_PHONE_ID+'/messages'
+        WHATS_TOKEN = 'Bearer ' + connect_config['WHATS_TOKEN']
+        URL = 'https://graph.facebook.com/v13.0/'+systemNumber+'/messages'
         headers = {'Authorization': WHATS_TOKEN}
         fileType = get_file_category(mimeType)
         data = {


### PR DESCRIPTION
*Description of changes:*
Healtcheck for Whatsapp was complaining about OpenSSL version. The same fix was applied for processConnectMessage already. It was missing in healtcheck.
Attachments from Amazon Connect to Whatsapp were not working. Based on another py files (that call graph APIs), the Authorization header must contain "Bearer + token" (not only token).

The deployment was tested and integration with Whatsapp works correctly after these 2 changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
